### PR TITLE
Workaround out of bounds cry decompress during lotad wild battle in r…

### DIFF
--- a/src/sound_mixer.c
+++ b/src/sound_mixer.c
@@ -465,6 +465,13 @@ static s8 sub_82DF758(struct MixerSource *chan, u32 current) {
     u32 blockOffset = current >> 6; // current / 64
     u8 * blockPtr;
     int i;
+    //In route 102 lotad wild battle when it growls crashes the game because it decompresses out of bounds data
+    //I gave it its own printf error so it wouldn't get forgotten as this needs a more proper fix
+    if (chan->wav->size < blockOffset * 0x21) {
+            printf("Out of bounds decompress in %s wav->size = %u blockPtr = %u\n", __func__, chan->wav->size, blockOffset * 0x21);
+            return gBDPCMBlockBuffer[current & 63];
+    }
+    
     if(chan->blockCount != blockOffset) { // decode block if not decoded
         s32 s;
         chan->blockCount = blockOffset;


### PR DESCRIPTION
…oute 102

Its a very specific crash, I do not know why it happens. Strangely enough this workaround doesn't break the cry when lotad growls