### PR TITLE
Enable audio during speedup and separate background music and sfx channels

### DIFF
--- a/include/gba/m4a_internal.h
+++ b/include/gba/m4a_internal.h
@@ -218,6 +218,9 @@ struct SoundInfo
     u8 gap2[16];
     struct SoundChannel chans[MAX_DIRECTSOUND_CHANNELS];
     float pcmBuffer[PCM_DMA_BUF_SIZE * 2];
+#ifdef PORTABLE
+    float sfxBuffer[PCM_DMA_BUF_SIZE * 2];
+#endif
 };
 
 struct SongHeader
@@ -379,6 +382,7 @@ extern u8 gMPlayMemAccArea[];
 extern struct PokemonCrySong gPokemonCrySong;
 extern struct PokemonCrySong gPokemonCrySongs[];
 
+extern struct MusicPlayerInfo gMPlayInfo_BGM;
 extern struct MusicPlayerInfo gPokemonCryMusicPlayers[];
 extern struct MusicPlayerTrack gPokemonCryTracks[];
 

--- a/include/platform.h
+++ b/include/platform.h
@@ -4,6 +4,8 @@
 #include "global.h"
 #include "siirtc.h"
 
+extern double timeScale;
+
 void Platform_StoreSaveFile(void);
 void Platform_ReadFlash(u16 sectorNum, u32 offset, u8 *dest, u32 size);
 void Platform_QueueAudio(float *audioBuffer, s32 samplesPerFrame);

--- a/include/sound_mixer.h
+++ b/include/sound_mixer.h
@@ -8,6 +8,10 @@
 #define MIXER_LOCKED PLAYER_UNLOCKED+1
 
 struct MP2KPlayerState;
+struct MixerSource;
+
+bool32 IsBgmChannel(struct MixerSource *chan);
+bool32 ShouldAdvanceBgm(void);
 
 struct MixerSource {
     u8 status;
@@ -109,6 +113,7 @@ struct SoundMixerState {
     void *reserved5;
     struct MixerSource chans[MAX_SAMPLE_CHANNELS];
     __attribute__((aligned(4))) float outBuffer[MIXED_AUDIO_BUFFER_SIZE * 2];
+    __attribute__((aligned(4))) float sfxBuffer[MIXED_AUDIO_BUFFER_SIZE * 2];
     //s8 outBuffer[MIXED_AUDIO_BUFFER_SIZE * 2];
 };
 

--- a/src/m4a.c
+++ b/src/m4a.c
@@ -3,6 +3,9 @@
 
 #ifdef PORTABLE
     #include "cgb_audio.h"
+
+typedef char SoundMixerStateMustMatchSoundInfo[
+    sizeof(struct SoundMixerState) == sizeof(struct SoundInfo) ? 1 : -1];
 #endif
 
 extern const u8 gCgb3Vol[];

--- a/src/music_player.c
+++ b/src/music_player.c
@@ -14,6 +14,23 @@ extern const u8 gScaleTable[];
 extern const u32 gFreqTable[];
 extern const u8 gClockTable[];
 float audioBuffer [MIXED_AUDIO_BUFFER_SIZE];
+static float fastMusicBuffer[MIXED_AUDIO_BUFFER_SIZE];
+static float fastSfxBuffer[MIXED_AUDIO_BUFFER_SIZE];
+static u16 fastAudioFrame;
+static u16 fastSfxOutputFrame;
+static u8 fastSfxPhase;
+static bool8 fastAudioActive;
+
+bool32 IsBgmChannel(struct MixerSource *chan)
+{
+    return chan->track >= (struct MP2KTrack *)gMPlayInfo_BGM.tracks
+        && chan->track < (struct MP2KTrack *)gMPlayInfo_BGM.tracks + gMPlayInfo_BGM.trackCount;
+}
+
+bool32 ShouldAdvanceBgm(void)
+{
+    return timeScale <= 1.0 || !fastAudioActive || fastAudioFrame == 0;
+}
 
 u32 umul3232H32(u32 a, u32 b) {
     u64 result = a;
@@ -354,12 +371,16 @@ void MP2KPlayerMain(void *voidPtrPlayer) {
     if (player->nextPlayerFunc != NULL) {
         player->nextPlayerFunc(player->nextPlayer);
     }
-    
+
     if (player->status & MUSICPLAYER_STATUS_PAUSE) {
         goto returnEarly;
     }
     FadeOutBody(voidPtrPlayer);
     if (player->status & MUSICPLAYER_STATUS_PAUSE) {
+        goto returnEarly;
+    }
+
+    if (player == (struct MP2KPlayerState *)&gMPlayInfo_BGM && !ShouldAdvanceBgm()) {
         goto returnEarly;
     }
     
@@ -752,15 +773,66 @@ void m4aSoundVSync(void)
     {
         s32 samplesPerFrame = mixer->samplesPerFrame * 2;
         float *m4aBuffer = mixer->outBuffer;
+        float *sfxBuffer = mixer->sfxBuffer;
         float *cgbBuffer = cgb_get_buffer();
         s32 dmaCounter = mixer->dmaCounter;
 
         if (dmaCounter > 1) {
             m4aBuffer += samplesPerFrame * (mixer->framesPerDmaCycle - (dmaCounter - 1));
+            sfxBuffer += samplesPerFrame * (mixer->framesPerDmaCycle - (dmaCounter - 1));
         }
 
-        for(u32 i = 0; i < samplesPerFrame; i++)
-            audioBuffer[i] = m4aBuffer[i] + cgbBuffer[i];
+        if (timeScale <= 1.0)
+        {
+            fastAudioActive = FALSE;
+            for(u32 i = 0; i < samplesPerFrame; i++)
+                audioBuffer[i] = m4aBuffer[i] + cgbBuffer[i] + sfxBuffer[i];
+        }
+        else
+        {
+            s32 inputFrames = samplesPerFrame / 2;
+
+            if (!fastAudioActive)
+            {
+                fastAudioActive = TRUE;
+                fastAudioFrame = 0;
+                fastSfxOutputFrame = 0;
+                fastSfxPhase = 0;
+            }
+            
+            if (ShouldAdvanceBgm())
+            {
+                for (u32 i = 0; i < samplesPerFrame; i++)
+                    fastMusicBuffer[i] = m4aBuffer[i] + cgbBuffer[i];
+            }
+
+            for (s32 inputFrame = 0; inputFrame < inputFrames; inputFrame++)
+            {
+                if (fastSfxPhase == 0)
+                {
+                    fastSfxBuffer[fastSfxOutputFrame * 2] = sfxBuffer[inputFrame * 2];
+                    fastSfxBuffer[fastSfxOutputFrame * 2 + 1] = sfxBuffer[inputFrame * 2 + 1];
+                    fastSfxOutputFrame++;
+                }
+                fastSfxPhase = (fastSfxPhase + 1) % 5;
+            }
+
+            if((s8)(--mixer->dmaCounter) <= 0)
+                mixer->dmaCounter = mixer->framesPerDmaCycle;
+
+            fastAudioFrame++;
+            if (fastAudioFrame == 5)
+            {
+                for (u32 i = 0; i < samplesPerFrame; i++)
+                    audioBuffer[i] = fastMusicBuffer[i] + fastSfxBuffer[i];
+                fastAudioFrame = 0;
+                fastSfxOutputFrame = 0;
+                fastSfxPhase = 0;
+                Platform_QueueAudio(audioBuffer, samplesPerFrame * 4);
+                return;
+            }
+            return;
+        }
 
         Platform_QueueAudio(audioBuffer, samplesPerFrame * 4);
         if((s8)(--mixer->dmaCounter) <= 0)

--- a/src/platform/sdl2.c
+++ b/src/platform/sdl2.c
@@ -141,12 +141,12 @@ int main(int argc, char **argv)
 
         if (!paused)
         {
-            double dt = fixedTimestep / timeScale; // TODO: Fix speedup
+            double dt = fixedTimestep / timeScale;
 
             curGameTime = SDL_GetPerformanceCounter();
             double deltaTime = (double)((curGameTime - lastGameTime) / (double)SDL_GetPerformanceFrequency());
-            if (deltaTime > (dt * 5))
-                deltaTime = dt;
+            if (deltaTime > (fixedTimestep * 5))
+                deltaTime = fixedTimestep * 5;
             lastGameTime = curGameTime;
 
             accumulator += deltaTime;
@@ -259,6 +259,11 @@ void Platform_QueueAudio(float *audioBuffer, s32 samplesPerFrame)
     SDL_QueueAudio(1, audioBuffer, samplesPerFrame);
 }
 
+static void ResetAudioQueue(void)
+{
+    SDL_ClearQueuedAudio(1);
+}
+
 
 static void CloseSaveFile()
 {
@@ -317,8 +322,7 @@ void ProcessEvents(void)
                 {
                     speedUp = false;
                     timeScale = 1.0;
-                    SDL_ClearQueuedAudio(1);
-                    SDL_PauseAudio(0);
+                    ResetAudioQueue();
                 }
                 break;
             }
@@ -353,7 +357,7 @@ void ProcessEvents(void)
                 {
                     speedUp = true;
                     timeScale = 5.0;
-                    SDL_PauseAudio(1);
+                    ResetAudioQueue();
                 }
                 break;
             }
@@ -422,12 +426,11 @@ u16 GetXInputKeys()
         {
             if (timeScale > 1.0)
             {
-                SDL_PauseAudio(1);
+                ResetAudioQueue();
             }
             else
             {
-                SDL_ClearQueuedAudio(1);
-                SDL_PauseAudio(0);
+                ResetAudioQueue();
             }
         }
     }

--- a/src/sound_mixer.c
+++ b/src/sound_mixer.c
@@ -10,10 +10,9 @@
 #define VCOUNT_VBLANK 160
 #define TOTAL_SCANLINES 228
 
-
 static inline void GenerateAudio(struct SoundMixerState *mixer, struct MixerSource *chan, struct WaveData2 *wav, float *outBuffer, u16 samplesPerFrame, float sampleRateReciprocal);
-void SampleMixer(struct SoundMixerState *mixer, u32 scanlineLimit, u16 samplesPerFrame, float *outBuffer, u8 dmaCounter, u16 maxBufSize);
 static inline bool32 TickEnvelope(struct MixerSource *chan, struct WaveData2 *wav);
+void SampleMixer(struct SoundMixerState *mixer, u32 scanlineLimit, u16 samplesPerFrame, float *musicBuffer, float *sfxBuffer, u8 dmaCounter, u16 maxBufSize);
 void GeneratePokemonSampleAudio(struct SoundMixerState *mixer, struct MixerSource *chan, s8 *current, float *outBuffer, u16 samplesPerFrame, float sampleRateReciprocal, s32 samplesLeftInWav, signed envR, signed envL, s32 loopLen);
 static s8 sub_82DF758(struct MixerSource *chan, u32 current);
 
@@ -38,54 +37,64 @@ void RunMixerFrame(void) {
         mixer->firstPlayerFunc(mixer->firstPlayer);
     }
     
-    mixer->cgbMixerFunc();
+    if (ShouldAdvanceBgm()) {
+        mixer->cgbMixerFunc();
+    }
     
     s32 samplesPerFrame = mixer->samplesPerFrame;
-    float *outBuffer = mixer->outBuffer;
+    float *musicBuffer = mixer->outBuffer;
+    float *sfxBuffer = mixer->sfxBuffer;
     s32 dmaCounter = mixer->dmaCounter;
     
     if (dmaCounter > 1) {
-        outBuffer += samplesPerFrame * (mixer->framesPerDmaCycle - (dmaCounter - 1)) * 2;
+        musicBuffer += samplesPerFrame * (mixer->framesPerDmaCycle - (dmaCounter - 1)) * 2;
+        sfxBuffer += samplesPerFrame * (mixer->framesPerDmaCycle - (dmaCounter - 1)) * 2;
     }
     
     //MixerRamFunc mixerRamFunc = ((MixerRamFunc)MixerCodeBuffer);
-    SampleMixer(mixer, maxScanlines, samplesPerFrame, outBuffer, dmaCounter, MIXED_AUDIO_BUFFER_SIZE);
+    SampleMixer(mixer, maxScanlines, samplesPerFrame, musicBuffer, sfxBuffer, dmaCounter, MIXED_AUDIO_BUFFER_SIZE);
     #ifdef PORTABLE
-        cgb_audio_generate(samplesPerFrame);
+        if (ShouldAdvanceBgm()) {
+            cgb_audio_generate(samplesPerFrame);
+        }
     #endif
 }
 
 
 
 //__attribute__((target("thumb")))
-void SampleMixer(struct SoundMixerState *mixer, u32 scanlineLimit, u16 samplesPerFrame, float *outBuffer, u8 dmaCounter, u16 maxBufSize) {
+void SampleMixer(struct SoundMixerState *mixer, u32 scanlineLimit, u16 samplesPerFrame, float *musicBuffer, float *sfxBuffer, u8 dmaCounter, u16 maxBufSize) {
     u32 reverb = mixer->reverb;
-    if (reverb) {
-        // The vanilla reverb effect outputs a mono sound from four sources:
-        //  - L/R channels as they were mixer->framesPerDmaCycle frames ago
-        //  - L/R channels as they were (mixer->framesPerDmaCycle - 1) frames ago
-        float *tmp1 = outBuffer;
-        float *tmp2;
-        if (dmaCounter == 2) {
-            tmp2 = mixer->outBuffer;
-        } else {
-            tmp2 = outBuffer + samplesPerFrame * 2;
-        }
-        uf16 i = 0;
-        do {
-            float s = tmp1[0] + tmp1[1] + tmp2[0] + tmp2[1];
-            s *= ((float)reverb / 512.0f);
-            tmp1[0] = tmp1[1] = s;
-            tmp1+=2;
-            tmp2+=2;
-        }
-        while(++i < samplesPerFrame);
-    } else {
-        // memset(outBuffer, 0, samplesPerFrame);
-        // memset(outBuffer + maxBufSize, 0, samplesPerFrame);
-        for (int i = 0; i < samplesPerFrame; i++) {
-            float *dst = &outBuffer[i*2];
-            dst[1] = dst[0] = 0.0f;
+    float *buffers[] = { musicBuffer, sfxBuffer };
+    for (u8 bufferId = 0; bufferId < 2; bufferId++) {
+        float *outBuffer = buffers[bufferId];
+        if (reverb) {
+            // The vanilla reverb effect outputs a mono sound from four sources:
+            //  - L/R channels as they were mixer->framesPerDmaCycle frames ago
+            //  - L/R channels as they were (mixer->framesPerDmaCycle - 1) frames ago
+            float *tmp1 = outBuffer;
+            float *tmp2;
+            if (dmaCounter == 2) {
+                tmp2 = (bufferId == 0) ? mixer->outBuffer : mixer->sfxBuffer;
+            } else {
+                tmp2 = outBuffer + samplesPerFrame * 2;
+            }
+            uf16 i = 0;
+            do {
+                float s = tmp1[0] + tmp1[1] + tmp2[0] + tmp2[1];
+                s *= ((float)reverb / 512.0f);
+                tmp1[0] = tmp1[1] = s;
+                tmp1+=2;
+                tmp2+=2;
+            }
+            while(++i < samplesPerFrame);
+            } else {
+            // memset(outBuffer, 0, samplesPerFrame);
+            // memset(outBuffer + maxBufSize, 0, samplesPerFrame);
+            for (int i = 0; i < samplesPerFrame; i++) {
+                float *dst = &outBuffer[i*2];
+                dst[1] = dst[0] = 0.0f;
+            }
         }
     }
     
@@ -106,9 +115,14 @@ void SampleMixer(struct SoundMixerState *mixer, u32 scanlineLimit, u16 samplesPe
             }
         }
         
-        if (TickEnvelope(chan, wav)) 
-        {
+        bool32 isBgm = IsBgmChannel(chan);
+        if (isBgm && !ShouldAdvanceBgm()) {
+            continue;
+        }
 
+        if (TickEnvelope(chan, wav))
+        {
+            float *outBuffer = isBgm ? musicBuffer : sfxBuffer;
             GenerateAudio(mixer, chan, wav, outBuffer, samplesPerFrame, sampleRateReciprocal);
         }
     }


### PR DESCRIPTION
SFX play faster during the speedup, music keeps playing in normal speed